### PR TITLE
cargo.bbclass: drop old work around

### DIFF
--- a/classes/cargo.bbclass
+++ b/classes/cargo.bbclass
@@ -11,13 +11,8 @@ def cargo_base_dep(d):
 
 BASEDEPENDS_append = " ${@cargo_base_dep(d)}"
 
-# FIXME: this is a workaround for a misbehavior in cargo when used with quilt.
-# See https://github.com/rust-lang/cargo/issues/978
-PATCHTOOL = "patch"
-
 # Cargo only supports in-tree builds at the moment
 B = "${S}"
-
 
 # In case something fails in the build process, give a bit more feedback on
 # where the issue occured


### PR DESCRIPTION
This work around was for an old version of cargo that we no longer use.
Newer versions resolve this issue.
